### PR TITLE
Don't pass user_id to repo.get when nil

### DIFF
--- a/lib/strategy/session.ex
+++ b/lib/strategy/session.ex
@@ -9,9 +9,20 @@ defmodule Doorman.Strategy.Session do
     repo = Application.get_env(:doorman, :repo) # Constable.Repo
     user_module = Application.get_env(:doorman, :user_module) # Constable.User
 
-    case repo.get(user_module, id) do
-      nil -> {:error, "Could not find user"}
-      user -> {:ok, user}
+    if id == nil do
+      {:error, errors[:nil_user_id]}
+    else
+      case repo.get(user_module, id) do
+        nil -> {:error, errors[:no_user]}
+        user -> {:ok, user}
+      end
     end
+  end
+
+  def errors do
+    %{
+      nil_user_id: "Session's user_id can't be nil",
+      no_user: "Could not find user"
+    }
   end
 end

--- a/test/strategy/session_test.exs
+++ b/test/strategy/session_test.exs
@@ -36,6 +36,15 @@ defmodule Doorman.Strategy.SessionTest do
     conn = conn
       |> Plug.Conn.put_session(:user_id, @invalid_id)
 
-    assert {:error, _reason} = Doorman.Strategy.Session.find_user(conn)
+    expected_reason = Doorman.Strategy.Session.errors[:no_user]
+    assert {:error, ^expected_reason} = Doorman.Strategy.Session.find_user(conn)
+  end
+
+  test "find_user returns error when session user_id is nil" do
+    Mix.Config.persist([doorman: %{repo: FakeSuccessRepo, user_module: Fake}])
+    conn = conn
+
+    expected_reason = Doorman.Strategy.Session.errors[:nil_user_id]
+    assert {:error, ^expected_reason} = Doorman.Strategy.Session.find_user(conn)
   end
 end


### PR DESCRIPTION
Ecto repo.get raises an error when passed nil instead of an integer.

This checks for nil before attempting to get the user in the session
strategy.
