### PR TITLE
Add login_strategy to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,20 @@ To get started add the following config to `config/config.exs`.
 ```elixir
 config :doorman,
   repo: MyApp.Repo,
-  user_module: MyApp.User
+  user_module: MyApp.User,
+  login_strategy: Doorman.Login.Session
 ```
 
-Next add the `Doorman` plug with the desired strategy. Currently
-`Doorman.Strategy.Session` is the only available strategy.
+Next add the `Doorman` plug which assigns `current_user` on `conn`.
 
 ```elixir
 plug Doorman, Doorman.Strategy.Session
 ```
 
-Finally, after authenticating your user call your strategies `login` method.
+Finally, after authenticating your user call the `Doorman.login/2` method in
+your conn pipeline also passing the user.
+
 
 ```elixir
-conn |> Doorman.Strategy.Session.login(user) |> redirect(to: "/")
+conn |> Doorman.login(user) |> redirect(to: "/")
 ```

--- a/lib/doorman.ex
+++ b/lib/doorman.ex
@@ -1,6 +1,18 @@
 defmodule Doorman do
   import Plug.Conn
 
+  # Public API
+
+  def login(conn, user) do
+    strategy = Application.get_env(:doorman, :login_strategy)
+    strategy.login(conn, user)
+  end
+
+  # Plug Callbacks
+
+  def init(nil) do
+    Application.get_env(:doorman, :login_strategy)
+  end
   def init(strategy) do
     strategy
   end

--- a/lib/login.ex
+++ b/lib/login.ex
@@ -1,0 +1,4 @@
+defmodule Doorman.Login do
+  @callback login(%Plug.Conn{}, %{id: Integer}) :: %Plug.Conn{}
+  @callback find_user(%Plug.Conn{}) :: %Plug.Conn{}
+end

--- a/lib/login/session.ex
+++ b/lib/login/session.ex
@@ -1,4 +1,6 @@
-defmodule Doorman.Strategy.Session do
+defmodule Doorman.Login.Session do
+  @behaviour Doorman.Login
+
   def login(conn, user) do
     conn
     |> Plug.Conn.put_session(:user_id, user.id)

--- a/test/doorman_test.exs
+++ b/test/doorman_test.exs
@@ -2,6 +2,8 @@ defmodule DoormanTest do
   use Doorman.ConnCase
   doctest Doorman
 
+  alias Doorman.Login.Session
+
   @valid_id 1
   @invalid_id 2
 
@@ -15,12 +17,38 @@ defmodule DoormanTest do
     end
   end
 
+  defmodule FakeLoginStrategy do
+    def login(conn, user), do: {conn, user}
+  end
+
+  test "login delegates to configured login_strategy" do
+    Mix.Config.persist([doorman: %{login_strategy: FakeLoginStrategy}])
+
+    fake_conn = %{conn: true}
+    fake_user = %{user: true}
+
+    {conn, user} = Doorman.login(fake_conn, fake_user)
+
+    assert conn == fake_conn
+    assert user == fake_user
+  end
+
+  test "init/1 strategy defaults to configured strategy" do
+    Mix.Config.persist([doorman: %{login_strategy: FakeLoginStrategy}])
+
+    assert Doorman.init(nil) == FakeLoginStrategy
+  end
+
+  test "init/1 strategy uses passed in strategy if provided" do
+    assert Doorman.init(Fake) == Fake
+  end
+
   test "using session strategy with valid id returns user" do
     Mix.Config.persist([doorman: %{repo: FakeSuccessRepo, user_module: Fake}])
 
     conn = conn
       |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Doorman.call(Doorman.Strategy.Session)
+      |> Doorman.call(Session)
 
     assert conn.assigns.current_user == %{}
   end
@@ -30,7 +58,7 @@ defmodule DoormanTest do
 
     conn = conn
       |> Plug.Conn.put_session(:user_id, @invalid_id)
-      |> Doorman.call(Doorman.Strategy.Session)
+      |> Doorman.call(Session)
 
     assert conn.assigns.current_user == nil
   end

--- a/test/login/session_test.exs
+++ b/test/login/session_test.exs
@@ -1,5 +1,7 @@
-defmodule Doorman.Strategy.SessionTest do
+defmodule Doorman.Login.SessionTest do
   use Doorman.ConnCase
+
+  alias Doorman.Login.Session
 
   @valid_id 1
   @invalid_id 2
@@ -18,7 +20,7 @@ defmodule Doorman.Strategy.SessionTest do
     conn
     |> Plug.Conn.put_session(:user_id, @valid_id)
 
-    conn = Doorman.Strategy.Session.login(conn, %{id: 1})
+    conn = Session.login(conn, %{id: 1})
 
     assert Plug.Conn.get_session(conn, :user_id) == 1
   end
@@ -28,7 +30,7 @@ defmodule Doorman.Strategy.SessionTest do
     conn = conn
       |> Plug.Conn.put_session(:user_id, @valid_id)
 
-    assert {:ok, _user} = Doorman.Strategy.Session.find_user(conn)
+    assert {:ok, _user} = Session.find_user(conn)
   end
 
   test "find_user returns {:error, reason} when does not exist" do
@@ -36,15 +38,15 @@ defmodule Doorman.Strategy.SessionTest do
     conn = conn
       |> Plug.Conn.put_session(:user_id, @invalid_id)
 
-    expected_reason = Doorman.Strategy.Session.errors[:no_user]
-    assert {:error, ^expected_reason} = Doorman.Strategy.Session.find_user(conn)
+    expected_reason = Session.errors[:no_user]
+    assert {:error, ^expected_reason} = Session.find_user(conn)
   end
 
   test "find_user returns error when session user_id is nil" do
     Mix.Config.persist([doorman: %{repo: FakeSuccessRepo, user_module: Fake}])
     conn = conn
 
-    expected_reason = Doorman.Strategy.Session.errors[:nil_user_id]
-    assert {:error, ^expected_reason} = Doorman.Strategy.Session.find_user(conn)
+    expected_reason = Session.errors[:nil_user_id]
+    assert {:error, ^expected_reason} = Session.find_user(conn)
   end
 end


### PR DESCRIPTION
Currently strategy methods for logging in must be called directly, eg:
`Doorman.Strategy.login`.
- Rename Strategy to Login.
- Add Login behavior.
- Add `login_strategy` config options.
- Add public methods on `Doorman` to delegate to `Login` modules.
