### PR TITLE
Allow custom field name for hashed password

### DIFF
--- a/lib/auth/bcrypt.ex
+++ b/lib/auth/bcrypt.ex
@@ -34,6 +34,8 @@ defmodule Doorman.Auth.Bcrypt do
   alias Comeonin.Bcrypt
   alias Ecto.Changeset
 
+  @default_hashed_password_field :hashed_password
+
   @doc """
   Takes a changeset and turns the virtual `password` field into a
   `hashed_password` change on the changeset.
@@ -44,7 +46,7 @@ defmodule Doorman.Auth.Bcrypt do
     if password do
       hashed_password = Bcrypt.hashpwsalt(password)
       changeset
-      |> Changeset.put_change(:hashed_password, hashed_password)
+      |> Changeset.put_change(hashed_password_field(), hashed_password)
     else
       changeset
     end
@@ -55,5 +57,12 @@ defmodule Doorman.Auth.Bcrypt do
   """
   def authenticate(user, password) do
     Bcrypt.checkpw(password, user.hashed_password)
+  end
+
+  @doc """
+  Returns the field name used for storing the hashed password.
+  """
+  def hashed_password_field do
+    Application.get_env(:doorman, :hashed_password_field, @default_hashed_password_field)
   end
 end

--- a/test/auth/bcrypt_test.exs
+++ b/test/auth/bcrypt_test.exs
@@ -31,6 +31,21 @@ defmodule Doorman.Auth.BcryptTest do
     refute changeset.changes[:hashed_password]
   end
 
+  test "hashed password field can be customised" do
+    hashed_password_field = Application.get_env(:doorman, :hashed_password_field)
+
+    try do
+      Application.put_env(:doorman, :hashed_password_field, :encrypted_password)
+
+      changeset = FakeUser.create_changeset(%{password: "foobar"})
+
+      refute changeset.changes[:hashed_password]
+      assert changeset.changes[:encrypted_password]
+    after
+      Application.put_env(:doorman, :hashed_password_field, hashed_password_field)
+    end
+  end
+
   test "authenticate returns true when password matches" do
     password = "secure"
     user = %FakeUser{hashed_password: Comeonin.Bcrypt.hashpwsalt(password)}


### PR DESCRIPTION
This allows altering the (currently hardcoded) hashed_password field
name.

I thought about perhaps allowing a custom value to be passed into
`hash_password` but it seems like this is something that should be
configured at compile time. Also, I guess it's very much an edge case
for this to be re-used in the same codebase with a different hashed
password field.

@BlakeWilliams Let me know what you think about this change in general. If you're open to it I'm happy to update the documentation as appropriate. I wanted to add this because I'm using Doorman on an existing schema.
