### PR TITLE
Fix minor typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ end
 
 ### Logging in users
 
-To login users we can use `Doorman.authenticate` and `Doorman.Session.login/2`.
+To login users we can use `Doorman.authenticate` and `Doorman.Login.Session.login/2`.
 
 ```elixir
 defmodule MyApp.SessionController do


### PR DESCRIPTION
Resolves #16

Correctly identify the module that the `login` method lives in.
