### PR TITLE
`nil` is a valid session_secret

### DIFF
--- a/lib/login/session.ex
+++ b/lib/login/session.ex
@@ -31,7 +31,7 @@ defmodule Doorman.Login.Session do
     repo = Application.get_env(:doorman, :repo)
     user_module = Application.get_env(:doorman, :user_module)
 
-    if !is_nil(id) && !is_nil(secret) do
+    if !is_nil(id) do
       repo.get_by(user_module, [id: id, session_secret: secret])
     end
   end


### PR DESCRIPTION
At a recent project, I introduced Doorman at a point where we already had a users table containing records. Quickly I found that I could not get these existing users authenticated. It took me some delving into Doorman's code to see what was going on.

When Doorman is added to a project that already has a populated users table, the existing records will start with `nil` values for `session_secret`. With the current implementation, these won’t be able to log in, as `nil` is not accepted as a secret when checking credentials.

I would argue that `nil` is as valid a secret as any other (at least for the first-time log in), and anyway this will be cycled to a "better" value upon first log in. Therefore, they should be accepted.

This decision would result in improved ergonomics for developers integrating Doorman into existing projects, while (I think?) not introducing any security concerns.