### PR TITLE
Add comeonin to mix application config

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Doorman.Mixfile do
   end
 
   def application do
-    [applications: [:logger]]
+    [applications: [:logger, :comeonin]]
   end
 
   defp deps do


### PR DESCRIPTION
This fixes an issue where the application would throw `function Comeonin.Bcrypt.hashpwsalt/1 is undefined (module Comeonin.Bcrypt is not available)` in production.